### PR TITLE
Archive API data locally and switch app to use local files

### DIFF
--- a/public/data/ny_current.json
+++ b/public/data/ny_current.json
@@ -1,0 +1,11 @@
+{
+  "_note": "PLACEHOLDER — run `node scripts/fetch-data.js` to replace with real archived data before the API shuts down on 2026-03-11",
+  "actuals": {
+    "cases": null,
+    "newCases": null,
+    "deaths": null,
+    "newDeaths": null,
+    "positiveTests": null,
+    "negativeTests": null
+  }
+}

--- a/public/data/ny_timeseries.json
+++ b/public/data/ny_timeseries.json
@@ -1,0 +1,4 @@
+{
+  "_note": "PLACEHOLDER — run `node scripts/fetch-data.js` to replace with real archived data before the API shuts down on 2026-03-11",
+  "actualsTimeseries": []
+}

--- a/scripts/fetch-data.js
+++ b/scripts/fetch-data.js
@@ -1,0 +1,69 @@
+/**
+ * fetch-data.js
+ *
+ * Run this script ONCE to archive COVID data from the Covid Act Now API
+ * before the API shuts down on March 11, 2026.
+ *
+ * Usage:
+ *   node scripts/fetch-data.js
+ *
+ * Requires Node.js 18+ (built-in fetch) or install node-fetch:
+ *   npm install --save-dev node-fetch   # if Node < 18
+ *
+ * Output:
+ *   public/data/ny_current.json
+ *   public/data/ny_timeseries.json
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const API_KEY = '1da95672607a441580c5b16c707c79bd';
+const BASE_URL = 'https://api.covidactnow.org/v2';
+const OUT_DIR = path.join(__dirname, '..', 'public', 'data');
+
+function fetchJson(url) {
+    return new Promise((resolve, reject) => {
+        https.get(url, (res) => {
+            if (res.statusCode !== 200) {
+                reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+                return;
+            }
+            let data = '';
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                } catch (e) {
+                    reject(new Error(`Failed to parse JSON: ${e.message}`));
+                }
+            });
+        }).on('error', reject);
+    });
+}
+
+async function main() {
+    if (!fs.existsSync(OUT_DIR)) {
+        fs.mkdirSync(OUT_DIR, { recursive: true });
+    }
+
+    console.log('Fetching current NY state data...');
+    const current = await fetchJson(`${BASE_URL}/state/NY.json?apiKey=${API_KEY}`);
+    const currentPath = path.join(OUT_DIR, 'ny_current.json');
+    fs.writeFileSync(currentPath, JSON.stringify(current, null, 2));
+    console.log(`  Saved -> ${currentPath}`);
+
+    console.log('Fetching NY state timeseries data (may be large)...');
+    const timeseries = await fetchJson(`${BASE_URL}/state/NY.timeseries.json?apiKey=${API_KEY}`);
+    const timeseriesPath = path.join(OUT_DIR, 'ny_timeseries.json');
+    fs.writeFileSync(timeseriesPath, JSON.stringify(timeseries, null, 2));
+    console.log(`  Saved -> ${timeseriesPath}`);
+
+    console.log('\nDone! Commit the files in public/data/ to the repository.');
+}
+
+main().catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+});

--- a/src/containers/ChartsPanel/ChartsPanel.js
+++ b/src/containers/ChartsPanel/ChartsPanel.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import axios from 'axios';
 
 import TotalCard from '../../components/TotalCard/TotalCard.js';
 import LineChart from '../../components/LineChart/LineChart.js';
@@ -16,36 +15,33 @@ class ChartsPanel extends Component {
     }
 
     componentDidMount () {
-        axios.get( 'https://api.covidactnow.org/v2/state/NY.json?apiKey=1da95672607a441580c5b16c707c79bd' )
-            .then( response => {
-                this.setState({current: response.data});
-                //console.log( this.state.current.actuals );
-                this.setState({loading: false});
+        fetch('/data/ny_current.json')
+            .then( response => response.json() )
+            .then( data => {
+                this.setState({current: data, loading: false});
             } )
             .catch(error => {
                 console.log(error);
-                this.setState({error: false});
+                this.setState({error: true, loading: false});
             });
 
-        axios.get( 'https://api.covidactnow.org/v2/state/NY.timeseries.json?apiKey=1da95672607a441580c5b16c707c79bd' )
-            .then( res => {
-                const actualsTimeseries = res.data.actualsTimeseries.reverse();
+        fetch('/data/ny_timeseries.json')
+            .then( response => response.json() )
+            .then( data => {
+                const actualsTimeseries = data.actualsTimeseries.reverse();
                 const slicedTime = [];
                 const maxVal = 10;
                 const delta = Math.floor(actualsTimeseries.length / maxVal);
-                
+
                 for ( let i=0; i < actualsTimeseries.length; i=i+delta) {
                     slicedTime.push(actualsTimeseries[i]);
                 }
 
-                this.setState({historic: slicedTime.reverse()});
-                //this.setState({today: this.state.historic['9']['date']});
-                //console.log( this.state.historic['0'] );
-                this.setState({loading2: false});
+                this.setState({historic: slicedTime.reverse(), loading2: false});
             } )
             .catch(error => {
                 console.log(error);
-                this.setState({error: false});
+                this.setState({error: true, loading2: false});
             });
 
     }
@@ -69,7 +65,7 @@ class ChartsPanel extends Component {
             <div >
             <Container>
                 <Row>
-                    <h5 className="Header">Using data from <a href="https://covidactnow.org/data-api" target="_blank" rel="noreferrer">Covid Act Now</a></h5>
+                    <h5 className="Header">Using archived data from <a href="https://covidactnow.org/data-api" target="_blank" rel="noreferrer">Covid Act Now</a></h5>
                 </Row>
                 <Row>
                     <p className="Header">Total current data:</p>


### PR DESCRIPTION
The Covid Act Now API is shutting down on 2026-03-11. This commit:
- Replaces axios API calls with fetch() loading from local JSON files in public/data/ (served as static assets, no bundling overhead)
- Adds public/data/ny_current.json and public/data/ny_timeseries.json as placeholder files (replace with real data via the fetch script)
- Adds scripts/fetch-data.js to archive the real API data before shutdown
- Removes the axios dependency from ChartsPanel

To populate the data files with real archived data, run:
  node scripts/fetch-data.js
Then commit the populated public/data/*.json files.

https://claude.ai/code/session_019Cdp4vUBdHzaMCwxuupY2Z